### PR TITLE
Link to article on listing cover image

### DIFF
--- a/themes/oncletom/layout/_blog/post-cover.ejs
+++ b/themes/oncletom/layout/_blog/post-cover.ejs
@@ -1,6 +1,6 @@
 <% if (post.cover){ %>
 <div class="post-cover">
-  <% if (post.cover.hasOwnProperty("link")){ -%><a href="<%= post.cover.link %>" rel="external"><% } %>
+  <% if (post.cover.hasOwnProperty("link")){ -%><a href="<% if(typeof href !== 'undefined') { %><%= href %><% } else { %><%= post.cover.link %><% } %>" rel="external"><% } %>
   <img src="<%= partial('../_cover_url', {post: post}) %>" alt="">
   <% if (post.cover.hasOwnProperty("link")){ %></a><% } %>
 </div>

--- a/themes/oncletom/layout/_blog/post-excerpt.ejs
+++ b/themes/oncletom/layout/_blog/post-excerpt.ejs
@@ -6,7 +6,7 @@
       </h1>
     </header>
 
-    <%- partial("post-cover", {post: post}) %>
+    <%- partial("post-cover", {post: post, href: config.root+post.path }) %>
 
     <div class="excerpt"><%- post.excerpt %></div>
 


### PR DESCRIPTION
Because it's a misleading CTA often bringing people outside of the article rather than its content.
