### PR TITLE
Restore absolute URLs generation in `coverUrl` helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@
 node_modules
 bower_components
 db.json
+public/*
 *.log

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,9 @@ before_deploy:
 - chmod 600 $TRAVIS_BUILD_DIR/id_rsa
 - ssh-add $TRAVIS_BUILD_DIR/id_rsa
 
+env:
+- NODE_ENV=production
+
 deploy:
   provider: script
   script: npm run deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ addons:
 
 before_install:
 - openssl aes-256-cbc -K $encrypted_a47c168ad38c_key -iv $encrypted_a47c168ad38c_iv -in id_rsa.enc -out $TRAVIS_BUILD_DIR/id_rsa -d
+- npm config set production false
 
 before_deploy:
 - eval "$(ssh-agent -s)"

--- a/package.json
+++ b/package.json
@@ -10,10 +10,12 @@
     "version": "3.2.2"
   },
   "scripts": {
-    "deploy": "NODE_ENV=production hexo deploy --generate",
-    "start": "hexo server",
+    "build": "hexo generate",
+    "deploy": "hexo deploy",
+    "start": "hexo server --debug",
     "new": "hexo new article",
     "postinstall": "bower install",
+    "pretest": "NODE_ENV=production npm run build",
     "test": "jshint themes/oncletom"
   },
   "dependencies": {

--- a/scripts/cover-url.js
+++ b/scripts/cover-url.js
@@ -1,19 +1,22 @@
 'use strict';
 
-hexo.extend.helper.register('coverUrl', function(post, config){
+const urlFor = hexo.extend.helper.store['url_for'].bind(hexo);
+
+hexo.extend.helper.register('coverUrl', (post, config) => {
+  const { default_cover, url:siteUrl } = config;
   var url = post.cover ? (post.cover.url || post.cover) : '';
 
-  if (!url && config.default_cover) {
-    url = config.default_cover;
+  if (!url && default_cover) {
+    url = default_cover;
   }
 
   if (url){
     if (url.match(/^\/images/) && process.env.NODE_ENV === 'production'){
-      url = config.url + hexo.extend.helper.store['url_for'](url);
+      url = `${siteUrl}${urlFor(url)}`;
     }
 
     if (url.match(/^\/\//)){
-      url = 'https:' + url;
+      url = `https:${url}`;
     }
 
     url = url.replace('_c_d.jpg', '_b_d.jpg');


### PR DESCRIPTION
Migration to `hexo@3.2` broke it because its internals changed.
Context has to be bound to the function in order to work again.